### PR TITLE
Test environment fixes

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -48,4 +48,4 @@ This method takes some parameters, the explanation of them is the following:
          - '01': offline payment: the user has to download a PDF file and go to a bank to complete the payment
          - '02': online payment: the user is presented a list of online bank platforms to complete the payment
 
-
+    - **test_environment**: (default: False) a boolean to use the testing environment of the Payment Service.

--- a/pymipago/__init__.py
+++ b/pymipago/__init__.py
@@ -10,21 +10,12 @@ from .utils import _calculate_payment_identification_notebook_60
 from .utils import _calculate_reference_number_with_control_digits_notebook_60
 from .utils import _parse_initialization_response
 
-
-import os
 import requests
-
-if os.environ.get('DEBUG', False):
-    from .constants import TEST_ENVIRON_INITIALIZATION_URL as INITIALIZATION_URL # noqa
-    from .constants import TEST_ENVIRON_SERVICE_URL as SERVICE_URL
-else:
-    from .constants import PROD_ENVIRON_INITIALIZATION_URL as INITIALIZATION_URL # noqa
-    from .constants import PROD_ENVIRON_SERVICE_URL as SERVICE_URL
 
 
 def make_payment_request(
         cpr, sender, format, suffix, reference_number, payment_limit_date,
-        quantity, language, return_url, payment_modes=['01', '02']):
+        quantity, language, return_url, payment_modes=['01', '02'], test_environment=False):
 
     """This method creates an XML file and creates a payment request on the
        Government platform in order to have the basis to be shown to the end
@@ -44,6 +35,13 @@ def make_payment_request(
        See the documentation for more information about the parameters
 
     """
+
+    if test_environment:
+        from .constants import TEST_ENVIRON_INITIALIZATION_URL as INITIALIZATION_URL # noqa
+        from .constants import TEST_ENVIRON_SERVICE_URL as SERVICE_URL
+    else:
+        from .constants import PROD_ENVIRON_INITIALIZATION_URL as INITIALIZATION_URL # noqa
+        from .constants import PROD_ENVIRON_SERVICE_URL as SERVICE_URL
 
     if cpr != '9052180':
         raise InvalidCPRValue('We only accept payments with CPR 9052180')

--- a/tests/test_pymipago.py
+++ b/tests/test_pymipago.py
@@ -16,15 +16,6 @@ from pymipago.exceptions import InvalidReferenceNumber
 class TestPymipago(unittest.TestCase):
     """Tests for `pymipago` package."""
 
-    def setUp(self):
-        """Set up test fixtures, if any."""
-        # set debug environment for testing
-        os.environ['DEBUG'] = 'True'
-
-    def tearDown(self):
-        """Tear down test fixtures, if any."""
-        del os.environ['DEBUG']
-
     def test_invalid_cpr_raises_exception(self):
         cpr = '010101'
         sender = '123456'
@@ -48,7 +39,8 @@ class TestPymipago(unittest.TestCase):
                 quantity,
                 language,
                 return_url,
-                payment_modes)
+                payment_modes,
+                test_environment=True)
 
     def test_invalid_format_raises_exception(self):
         cpr = '9052180'
@@ -73,7 +65,8 @@ class TestPymipago(unittest.TestCase):
                 quantity,
                 language,
                 return_url,
-                payment_modes)
+                payment_modes,
+                test_environment=True)
 
     def test_invalid_formated_reference_number_raises_exception(self):
         cpr = '9052180'
@@ -98,7 +91,8 @@ class TestPymipago(unittest.TestCase):
                 quantity,
                 language,
                 return_url,
-                payment_modes)
+                payment_modes,
+                test_environment=True)
 
     def test_correct_payment_request(self):
         cpr = '9052180'
@@ -122,7 +116,8 @@ class TestPymipago(unittest.TestCase):
             quantity,
             language,
             return_url,
-            payment_modes)
+            payment_modes,
+            test_environment=True)
 
         self.assertTrue(html.find(payment_code) != -1)
         self.assertTrue(payment_code.isdigit())


### PR DESCRIPTION
Instead of using an environment variable to set the use of the test environment, use an explicit parameter.